### PR TITLE
Docker file for Kcorrect 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+FROM jupyter/scipy-notebook:db3ee82ad08a
+#FROM continuumio/miniconda3
+
+
+#########
+# Setup #
+#########
+
+ENV HOME /home/jovyan
+WORKDIR $HOME
+
+# Clone lcbg repo
+RUN git clone https://github.com/crawfordsm/lcbg.git
+ENV LCBGDIR $HOME/lcbg
+
+# Clone kcorrect @ dcad853
+RUN git clone https://github.com/blanton144/kcorrect.git
+ENV KCORRECT_DIR $HOME/kcorrect
+
+# Clone kcorrect_python @ 8ea0c62
+RUN git clone https://github.com/nirinA/kcorrect_python.git
+ENV KCORRECT_PYTHON_DIR $HOME/kcorrect_python
+
+
+########################################
+# Setup Conda and Install Requirements #
+########################################
+
+#RUN conda env update --file $LCBGDIR/environment.yml
+RUN conda env create -f $LCBGDIR/environment.yml
+ENV PATH /opt/conda/envs/lcbg/bin:$PATH
+RUN echo "source activate lcbg" >> $HOME/.bashrc
+
+ENV CONDA_DEFAULT_ENV lcbg
+
+
+####################
+# Install kcorrect #
+####################
+
+ENV PATH $KCORRECT_DIR/bin:$PATH
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$KCORRECT_DIR/lib
+ENV IDL_PATH $KCORRECT_DIR/pro
+
+WORKDIR $KCORRECT_DIR
+
+RUN kevilmake -k
+
+WORKDIR $HOME
+
+
+###########################
+# Install kcorrect_python #
+###########################
+
+WORKDIR $KCORRECT_PYTHON_DIR
+
+RUN python setup.py install
+
+WORKDIR $HOME
+
+
+################
+# Install lcbg #
+################
+
+WORKDIR $LCBGDIR
+
+RUN python setup.py develop
+
+WORKDIR $HOME
+

--- a/docker.py
+++ b/docker.py
@@ -1,0 +1,19 @@
+import os
+from sys import argv
+
+if __name__ == '__main__':
+    if len(argv) < 2:
+        print('Command not supplied')
+        print('python docker.py build')
+        print('python docker.py run')
+        print('python docker.py run_safe # (does not mount the host copy of lcbg dir)')
+
+    elif argv[1] == 'build' or argv[1] == '-b' or argv[1] == 'b':
+        os.system('docker build -t lcbg .')
+
+    elif argv[1] == 'run' or argv[1] == '-r' or argv[1] == 'r':
+        path_to_this_dir = os.path.dirname(os.path.abspath(__file__))
+        os.system("docker run --mount type=bind,src={},dst=/home/jovyan/lcbg -it -p 8888:8888 lcbg".format(path_to_this_dir))
+
+    elif argv[1] == 'run_safe':
+        os.system('docker run -it -p 8888:8888 lcbg')

--- a/docker.py
+++ b/docker.py
@@ -1,19 +1,52 @@
 import os
 from sys import argv
 
+def mount_bind_command(src, dst):
+    return "--mount type=bind,src={},dst={}".format(src, dst)
+
 if __name__ == '__main__':
     if len(argv) < 2:
         print('Command not supplied')
         print('python docker.py build')
-        print('python docker.py run')
+        print('python docker.py run [extra_mount_paths]')
         print('python docker.py run_safe # (does not mount the host copy of lcbg dir)')
-
-    elif argv[1] == 'build' or argv[1] == '-b' or argv[1] == 'b':
+    
+    # Build
+    # -----
+    # Command to build the Dockerfile
+    elif argv[1] == 'build' or argv[1].replace("-", "") == "b":
         os.system('docker build -t lcbg .')
-
-    elif argv[1] == 'run' or argv[1] == '-r' or argv[1] == 'r':
+    
+    # Mount and Run 
+    # -------------
+    # Command to run the docker image in a container.
+    # This will mount the host version of the repo so any changes to the code 
+    # in the host repo will be available in the docker container and the environment.
+    # Thus the docker container will use the host's version of lcbg module since the 
+    # environment in the container is installed using `python setup.py develop`. 
+    # (you are able to update code on host without having to reinstall in the container)
+    elif argv[1] == 'run' or argv[1].replace("-", "") == "r":
         path_to_this_dir = os.path.dirname(os.path.abspath(__file__))
-        os.system("docker run --mount type=bind,src={},dst=/home/jovyan/lcbg -it -p 8888:8888 lcbg".format(path_to_this_dir))
+        command = "docker run"
+        command += " " + mount_bind_command(path_to_this_dir, "/home/jovyan/lcbg")
+        
+        # This section mounts (bind) any number of volumes on the host into the docker container.
+        # The volumes are mounted into the `mount` folder inside the container.
+        # Any edits there will also apply to the host version of the files. 
+        if len(argv) > 2:
+            for path in argv[2:]:
+                src = os.path.abspath(path)
+                dst = "/home/jovyan/mount/{}".format(os.path.basename(path))
+                command += " " + mount_bind_command(src, dst)
 
+        command += " " + "-it -p 8888:8888 lcbg"
+
+        print(">>>", command, "\n")
+
+        os.system(command)
+        
+    # Regular Run
+    # -----------
+    # Nothing is mounted on to the container.
     elif argv[1] == 'run_safe':
         os.system('docker run -it -p 8888:8888 lcbg')

--- a/docker.py
+++ b/docker.py
@@ -10,33 +10,37 @@ if __name__ == '__main__':
         print('python docker.py build')
         print('python docker.py run [extra_mount_paths]')
         print('python docker.py run_safe # (does not mount the host copy of lcbg dir)')
-    
+
     # Build
     # -----
     # Command to build the Dockerfile
     elif argv[1] == 'build' or argv[1].replace("-", "") == "b":
         os.system('docker build -t lcbg .')
-    
-    # Mount and Run 
+
+    # Mount and Run
     # -------------
     # Command to run the docker image in a container.
-    # This will mount the host version of the repo so any changes to the code 
+    # This will mount the host version of the repo so any changes to the code
     # in the host repo will be available in the docker container and the environment.
-    # Thus the docker container will use the host's version of lcbg module since the 
-    # environment in the container is installed using `python setup.py develop`. 
+    # Thus the docker container will use the host's version of lcbg module since the
+    # environment in the container is installed using `python setup.py develop`.
     # (you are able to update code on host without having to reinstall in the container)
     elif argv[1] == 'run' or argv[1].replace("-", "") == "r":
         path_to_this_dir = os.path.dirname(os.path.abspath(__file__))
         command = "docker run"
         command += " " + mount_bind_command(path_to_this_dir, "/home/jovyan/lcbg")
-        
+
         # This section mounts (bind) any number of volumes on the host into the docker container.
         # The volumes are mounted into the `mount` folder inside the container.
-        # Any edits there will also apply to the host version of the files. 
+        # Any edits there will also apply to the host version of the files.
+        mounted_list = []
         if len(argv) > 2:
             for path in argv[2:]:
                 src = os.path.abspath(path)
                 dst = "/home/jovyan/mount/{}".format(os.path.basename(path))
+                if dst in mounted_list:
+                    raise Exception("Mount request includes multiple files or folders with the same name")
+                mounted_list.append(dst)
                 command += " " + mount_bind_command(src, dst)
 
         command += " " + "-it -p 8888:8888 lcbg"
@@ -44,7 +48,7 @@ if __name__ == '__main__':
         print(">>>", command, "\n")
 
         os.system(command)
-        
+
     # Regular Run
     # -----------
     # Nothing is mounted on to the container.


### PR DESCRIPTION
closes #28 
I needed to host the code on my Mac and I remembered that @crawfordsm was successful in making one fairly quickly so I made a docker file.
 

- `Dockerfile`: a docker file based on `jupyter/scipy-notebook` which builds this repo and kcorrect code (python wrapper as well).

- `docker.py`: helper script to wrap terminal commands:

    ```
    python docker.py build
    python docker.py run [extra_mount_paths]
    python docker.py run_safe # (does not mount the host copy of lcbg dir)
    ```